### PR TITLE
Ignore HTTP errors from status post

### DIFF
--- a/okdata/aws/status/wrapper.py
+++ b/okdata/aws/status/wrapper.py
@@ -2,6 +2,8 @@ import os
 import time
 from functools import wraps
 
+from requests.exceptions import HTTPError
+
 from .sdk import Status
 from .model import StatusData, TraceStatus, TraceEventStatus
 
@@ -29,7 +31,10 @@ def status_wrapper(handler):
             end_time = time.perf_counter_ns()
             duration_ms = (end_time - start_time) / 1000000.0
             _status_logger.add(duration=duration_ms)
-            _status_logger.done()
+            try:
+                _status_logger.done()
+            except HTTPError:
+                pass
             _status_logger = None
 
     return wrapper

--- a/okdata/aws/status/wrapper.py
+++ b/okdata/aws/status/wrapper.py
@@ -4,8 +4,9 @@ from functools import wraps
 
 from requests.exceptions import HTTPError
 
-from .sdk import Status
 from .model import StatusData, TraceStatus, TraceEventStatus
+from .sdk import Status
+from okdata.aws.logging import log_exception
 
 _status_logger = None
 
@@ -33,7 +34,8 @@ def status_wrapper(handler):
             _status_logger.add(duration=duration_ms)
             try:
                 _status_logger.done()
-            except HTTPError:
+            except HTTPError as e:
+                log_exception(e)
                 pass
             _status_logger = None
 


### PR DESCRIPTION
Don't raise exceptions when getting HTTP error responses from the status API in the status wrapper.