### PR TITLE
Use standard logging for status API exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * The `okdata` namespace package now uses the old-style `pkg_resources`
   declaration instead of being an implicit namespace package.
 
+* The status wrapper no longer throws an exception when receiving an HTTP error
+  response from the status API, but logs it instead.
+
 ## 0.2.0
 
 * Added `status_wrapper` and `status_add` from common-python under

--- a/okdata/aws/status/wrapper.py
+++ b/okdata/aws/status/wrapper.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import time
 from functools import wraps
@@ -6,7 +7,6 @@ from requests.exceptions import HTTPError
 
 from .model import StatusData, TraceStatus, TraceEventStatus
 from .sdk import Status
-from okdata.aws.logging import log_exception
 
 _status_logger = None
 
@@ -35,7 +35,7 @@ def status_wrapper(handler):
             try:
                 _status_logger.done()
             except HTTPError as e:
-                log_exception(e)
+                logging.exception(f"Error response from status API: {e}")
                 pass
             _status_logger = None
 


### PR DESCRIPTION
The logging wrapper is not guaranteed to be set up at this point, so use Python's standard logging facilities instead.