### PR TITLE
DP-2170 Unglobalize async logging wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## ?.?.?
+
+* Fixed a bug in the asynchronous variant of the logging wrapper.
+
 ## 0.4.0
 
 * An asynchronous variant of the logging wrapper is now available:


### PR DESCRIPTION
Don't use the global logging instance in the asynchronous logging wrapper. Short story: Unsynchronized global state and async code doesn't mix well.