### PR TITLE
Switch to 1Password for publishing credentials

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ build: $(BUILD_VENV)/bin/wheel $(BUILD_VENV)/bin/twine
 
 .PHONY: publish
 publish:
-	username=$$(gopass show dataplatform/websites/pypi.org/origo-dataplatform username) &&\
-	password=$$(gopass show --password dataplatform/websites/pypi.org/origo-dataplatform) &&\
+	username=$$(op read op://Dataspeilet/pypi-upload-token/username) &&\
+	password=$$(op read op://Dataspeilet/pypi-upload-token/credential) &&\
 	python -m twine upload -u $$username -p $$password dist/*
 
 ###


### PR DESCRIPTION
Also use the new PyPI API token system for uploading as username + password no longer works after we enabled 2FA.