### PR TITLE
Bump okdata-sdk requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## ?.?.?
+
+* Updated dependencies.
+
 ## 2.0.0
 
 * Added support for Python 3.10, 3.11, and 3.12.

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ idna==3.3
     #   requests
 jsonschema==4.1.2
     # via okdata-sdk
-okdata-sdk==0.9.1
+okdata-sdk==3.1.0
     # via okdata-aws (setup.py)
 pyasn1==0.4.8
     # via
@@ -33,7 +33,9 @@ pyjwt==2.4.0
 pyrsistent==0.18.0
     # via jsonschema
 python-jose==3.3.0
-    # via python-keycloak
+    # via
+    #   okdata-sdk
+    #   python-keycloak
 python-keycloak==0.26.1
     # via okdata-sdk
 requests==2.31.0
@@ -54,4 +56,6 @@ structlog==21.2.0
 typing-extensions==3.10.0.2
     # via pydantic
 urllib3==1.26.18
-    # via requests
+    # via
+    #   okdata-sdk
+    #   requests

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.12",
     ],
     install_requires=[
-        "okdata-sdk>=0.9.1",
+        "okdata-sdk>=3,<4",
         "pydantic",
         "requests",
         "starlette>=0.25.0,<1.0.0",


### PR DESCRIPTION
Bump the okdata-sdk version requirement to support newer Python versions and remove deprecation warnings.