### PR TITLE
Add SDK config parameter to `status_wrapper`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## ?.?.? - Unreleased
+
+* `okdata.aws.status.status_wrapper` now supports an optional argument for
+  configuring the SDK instance used to call the status API.
+
+  Current users must update their usage from:
+
+  ```python
+  @status_wrapper
+  def foo():
+      ...
+  ```
+
+  To:
+
+  ```python
+  @status_wrapper()
+  def foo():
+      ...
+  ```
+
 ## 3.0.1 - 2024-03-21
 
 * Status data exceptions are now accurately converted to strings when exported

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The handler function should set the `domain` and `domain_id` values using the
 ```python
 from okdata.aws.status import status_wrapper, status_add
 
-@status_wrapper
+@status_wrapper()
 def my_lambda_handler(event, context):
     status_add(domain="dataset", domain_id=f"{dataset_id}/{version}")
 


### PR DESCRIPTION
Add an optional parameter to `okdata.aws.status.status_wrapper` for configuring the SDK instance used to call the status API.